### PR TITLE
allow this pod to work with iOS 9

### DIFF
--- a/rembrandt.podspec
+++ b/rembrandt.podspec
@@ -26,7 +26,7 @@ Rembrandt is an image library for swift 3 with objective-C bindings, based on Re
   s.author           = { 'Carsten Przyluczky' => 'carsten.przyluczky@9elements.com' }
   s.source           = { :git => 'https://github.com/imgly/RembrandtSwift.git', :tag => s.version.to_s }
 
-  s.ios.deployment_target = '10.0.0'
+  s.ios.deployment_target = '9.0.0'
 
   s.source_files = 'rembrandt/Classes/**/*'
 


### PR DESCRIPTION
RembrandtSwift totally works on iOS 9, but the podspec is set to only support 10+.

Updating the podspec to allow this to be included in apps that need to support iOS 9.